### PR TITLE
Fixed for multiple joins & joins based on A->B->C.  Fixed compiler warnings.

### DIFF
--- a/SharkORM.podspec
+++ b/SharkORM.podspec
@@ -1,0 +1,137 @@
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Open source iOS/macOS/tvOS ORM, fast and agile designed to be simple and logical
+  #	 to use.
+  #
+
+  s.name         = "SharkORM"
+  s.version      = "2.0.0"
+  s.summary      = "ORM for iOS, tvOS & macOS"
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.description  = <<-DESC
+Shark is an open source ORM, designed from the start to be low maintenance and natural to use, developers choose shark for its power and simplicity.
+
+With just a couple of lines of code getting you started, it is faster to get started than any other database system.
+
+Real class objects are used and extended, with a simple persistence model and the datastore is always refactored to your class structures, with no effort from the developer.
+
+Objects are retrieved using a FLUENT interface, but the same methods give you COUNT, SUM, GROUP & DISTINCT.
+
+Your object model is tuneable with indexes and query optimisations and it is entirely thread-safe in every situation, in fact, you don't have to worry about it at all.
+                   DESC
+
+  s.homepage     = "http://sharkorm.com/"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      =  { :type => "MIT", :file => "LICENSE" }
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author             = { "Adrian Herridge" => "adrian@sharkorm.com" }
+  # Or just: s.author    = ""
+  # s.authors            = { "" => "" }
+  s.social_media_url   = "http://twitter.com/editfmah"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+  # s.platform     = :ios, "5.0"
+
+  #  When using multiple platforms
+  s.ios.deployment_target = "7.0"
+  s.osx.deployment_target = "10.8"
+  s.watchos.deployment_target = "3.0"
+  s.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  #s.source       = { :git => "https://github.com/sharksync/sharkorm.git", :tag => "#{s.version}" }
+   s.source       = { :git => "https://github.com/sharksync/sharkorm.git", :tag => "test" }
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "SharkORM/**/*.{h,m,c}"
+  #s.exclude_files = "Classes/Exclude"
+
+  s.public_header_files = "SharkORM/Core/DBAccess.h", "SharkORM/Core/SharkORM.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  # s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
+end

--- a/SharkORM.podspec
+++ b/SharkORM.podspec
@@ -8,13 +8,7 @@ Pod::Spec.new do |s|
 
   s.name         = "SharkORM"
   s.version      = "2.0.0"
-  s.summary      = "ORM for iOS, tvOS & macOS"
-
-  # This description is used to generate tags and improve search results.
-  #   * Think: What does it do? Why did you write it? What is the focus?
-  #   * Try to keep it short, snappy and to the point.
-  #   * Write the description between the DESC delimiters below.
-  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.summary      = "SQLite based ORM for iOS, tvOS & macOS"
   s.description  = <<-DESC
 Shark is an open source ORM, designed from the start to be low maintenance and natural to use, developers choose shark for its power and simplicity.
 
@@ -28,110 +22,16 @@ Your object model is tuneable with indexes and query optimisations and it is ent
                    DESC
 
   s.homepage     = "http://sharkorm.com/"
-  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
-
-
-  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Licensing your code is important. See http://choosealicense.com for more info.
-  #  CocoaPods will detect a license file if there is a named LICENSE*
-  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
-  #
-
   s.license      =  { :type => "MIT", :file => "LICENSE" }
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-
-
-  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the authors of the library, with email addresses. Email addresses
-  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
-  #  accepts just a name if you'd rather not provide an email address.
-  #
-  #  Specify a social_media_url where others can refer to, for example a twitter
-  #  profile URL.
-  #
-
   s.author             = { "Adrian Herridge" => "adrian@sharkorm.com" }
-  # Or just: s.author    = ""
-  # s.authors            = { "" => "" }
   s.social_media_url   = "http://twitter.com/editfmah"
-
-  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If this Pod runs only on iOS or OS X, then specify the platform and
-  #  the deployment target. You can optionally include the target after the platform.
-  #
-
-  # s.platform     = :ios
-  # s.platform     = :ios, "5.0"
-
-  #  When using multiple platforms
   s.ios.deployment_target = "7.0"
   s.osx.deployment_target = "10.8"
-  s.watchos.deployment_target = "3.0"
   s.tvos.deployment_target = "9.0"
-
-
-  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Specify the location from where the source should be retrieved.
-  #  Supports git, hg, bzr, svn and HTTP.
-  #
-
-  #s.source       = { :git => "https://github.com/sharksync/sharkorm.git", :tag => "#{s.version}" }
-   s.source       = { :git => "https://github.com/sharksync/sharkorm.git", :tag => "test" }
-
-  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  CocoaPods is smart about how it includes source code. For source files
-  #  giving a folder will include any swift, h, m, mm, c & cpp files.
-  #  For header files it will include any header in the folder.
-  #  Not including the public_header_files will make all headers public.
-  #
-
+  s.source       = { :git => "https://github.com/sharksync/sharkorm.git", :tag => "#{s.version}" }
   s.source_files  = "SharkORM/**/*.{h,m,c}"
-  #s.exclude_files = "Classes/Exclude"
-
   s.public_header_files = "SharkORM/Core/DBAccess.h", "SharkORM/Core/SharkORM.h"
 
 
-  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  A list of resources included with the Pod. These are copied into the
-  #  target bundle with a build phase script. Anything else will be cleaned.
-  #  You can preserve files from being cleaned, please don't preserve
-  #  non-essential files like tests, examples and documentation.
-  #
-
-  # s.resource  = "icon.png"
-  # s.resources = "Resources/*.png"
-
-  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
-
-
-  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  Link your library with frameworks, or libraries. Libraries do not include
-  #  the lib prefix of their name.
-  #
-
-  # s.framework  = "SomeFramework"
-  # s.frameworks = "SomeFramework", "AnotherFramework"
-
-  # s.library   = "iconv"
-  # s.libraries = "iconv", "xml2"
-
-
-  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
-  #
-  #  If your library depends on compiler flags you can set them in the xcconfig hash
-  #  where they will only apply to your library. If you depend on other Podspecs
-  #  you can include multiple dependencies to ensure it works.
-
-  # s.requires_arc = true
-
-  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
-  # s.dependency "JSONKit", "~> 1.4"
-
 end
+

--- a/SharkORM.podspec
+++ b/SharkORM.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "SharkORM"
-  s.version      = "2.0.0"
+  s.version      = "2.0.1"
   s.summary      = "SQLite based ORM for iOS, tvOS & macOS"
   s.description  = <<-DESC
 Shark is an open source ORM, designed from the start to be low maintenance and natural to use, developers choose shark for its power and simplicity.

--- a/SharkORM.podspec
+++ b/SharkORM.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "SharkORM"
-  s.version      = "2.0.1"
+  s.version      = "2.0.2"
   s.summary      = "SQLite based ORM for iOS, tvOS & macOS"
   s.description  = <<-DESC
 Shark is an open source ORM, designed from the start to be low maintenance and natural to use, developers choose shark for its power and simplicity.

--- a/SharkORM.xcodeproj/project.pbxproj
+++ b/SharkORM.xcodeproj/project.pbxproj
@@ -144,7 +144,7 @@
 		E0F413F41CF632120085166C /* SRKTransactionGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = E0F4139E1CF632120085166C /* SRKTransactionGroup.h */; };
 		E0F413F51CF632120085166C /* SRKTransactionGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E0F4139F1CF632120085166C /* SRKTransactionGroup.m */; };
 		E0F413F61CF632120085166C /* SRKTransactionGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = E0F4139F1CF632120085166C /* SRKTransactionGroup.m */; };
-		E0F413F71CF632120085166C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = E0F413A11CF632120085166C /* sqlite3.c */; settings = {COMPILER_FLAGS = "-w"; }; };
+		E0F413F71CF632120085166C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = E0F413A11CF632120085166C /* sqlite3.c */; };
 		E0F413F81CF632120085166C /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = E0F413A11CF632120085166C /* sqlite3.c */; settings = {COMPILER_FLAGS = "-w"; }; };
 		E0F413F91CF632120085166C /* sqlite3.h in Headers */ = {isa = PBXBuildFile; fileRef = E0F413A21CF632120085166C /* sqlite3.h */; };
 		E0F413FA1CF632120085166C /* sqlite3ext.h in Headers */ = {isa = PBXBuildFile; fileRef = E0F413A31CF632120085166C /* sqlite3ext.h */; };

--- a/SharkORM.xcodeproj/project.pbxproj
+++ b/SharkORM.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		E003204D1CFA58FF00240C44 /* WidePerson.m in Sources */ = {isa = PBXBuildFile; fileRef = E00320451CFA58FF00240C44 /* WidePerson.m */; };
 		E00320631CFB8F0B00240C44 /* Persistence.m in Sources */ = {isa = PBXBuildFile; fileRef = E00320621CFB8F0B00240C44 /* Persistence.m */; };
 		E012E0361D0AEDDE00B6F741 /* TODO.rtf in Resources */ = {isa = PBXBuildFile; fileRef = E012E0351D0AEDDD00B6F741 /* TODO.rtf */; };
+		E040B5BF1D1479E900FCC830 /* Examples.m in Sources */ = {isa = PBXBuildFile; fileRef = E040B5BE1D1479E900FCC830 /* Examples.m */; };
+		E040B5C31D14970D00FCC830 /* Joins.m in Sources */ = {isa = PBXBuildFile; fileRef = E040B5C21D14970D00FCC830 /* Joins.m */; };
 		E092CB051D00964700C6C8CD /* DBAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = E092CB041D0095A300C6C8CD /* DBAccess.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E092CB081D00DBE800C6C8CD /* Performance.m in Sources */ = {isa = PBXBuildFile; fileRef = E092CB071D00DBE800C6C8CD /* Performance.m */; };
 		E0C450A61D107AA8003FA21D /* SRKEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = E0F413631CF632120085166C /* SRKEvent.m */; };
@@ -186,6 +188,10 @@
 		E00320611CFB8F0B00240C44 /* Persistence.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Persistence.h; sourceTree = "<group>"; };
 		E00320621CFB8F0B00240C44 /* Persistence.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Persistence.m; sourceTree = "<group>"; };
 		E012E0351D0AEDDD00B6F741 /* TODO.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; name = TODO.rtf; path = SharkORM/TODO.rtf; sourceTree = "<group>"; };
+		E040B5BD1D1479E900FCC830 /* Examples.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Examples.h; sourceTree = "<group>"; };
+		E040B5BE1D1479E900FCC830 /* Examples.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Examples.m; sourceTree = "<group>"; };
+		E040B5C11D14970D00FCC830 /* Joins.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Joins.h; sourceTree = "<group>"; };
+		E040B5C21D14970D00FCC830 /* Joins.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Joins.m; sourceTree = "<group>"; };
 		E092CB041D0095A300C6C8CD /* DBAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DBAccess.h; sourceTree = "<group>"; };
 		E092CB061D00DBE800C6C8CD /* Performance.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Performance.h; sourceTree = "<group>"; };
 		E092CB071D00DBE800C6C8CD /* Performance.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Performance.m; sourceTree = "<group>"; };
@@ -383,6 +389,24 @@
 			path = "Transaction Tests";
 			sourceTree = "<group>";
 		};
+		E040B5BC1D1479CF00FCC830 /* Examples */ = {
+			isa = PBXGroup;
+			children = (
+				E040B5BD1D1479E900FCC830 /* Examples.h */,
+				E040B5BE1D1479E900FCC830 /* Examples.m */,
+			);
+			path = Examples;
+			sourceTree = "<group>";
+		};
+		E040B5C01D1496FB00FCC830 /* Joins */ = {
+			isa = PBXGroup;
+			children = (
+				E040B5C11D14970D00FCC830 /* Joins.h */,
+				E040B5C21D14970D00FCC830 /* Joins.m */,
+			);
+			path = Joins;
+			sourceTree = "<group>";
+		};
 		E0DFA4281D107A1800DFDB6F /* TestTargetApplication */ = {
 			isa = PBXGroup;
 			children = (
@@ -441,6 +465,8 @@
 		E0F413551CF6312A0085166C /* SharkORMTests */ = {
 			isa = PBXGroup;
 			children = (
+				E040B5C01D1496FB00FCC830 /* Joins */,
+				E040B5BC1D1479CF00FCC830 /* Examples */,
 				E00320321CFA58FF00240C44 /* Events Test */,
 				E00320331CFA58FF00240C44 /* Multithread Tests */,
 				E00320341CFA58FF00240C44 /* Performance Tests */,
@@ -871,6 +897,7 @@
 				E0F413E31CF632120085166C /* SRKRelationship.m in Sources */,
 				E0F413F61CF632120085166C /* SRKTransactionGroup.m in Sources */,
 				E0F413EE1CF632120085166C /* SRKContext.m in Sources */,
+				E040B5BF1D1479E900FCC830 /* Examples.m in Sources */,
 				E0F413D61CF632120085166C /* SRKRegistryEntry.m in Sources */,
 				E003204D1CFA58FF00240C44 /* WidePerson.m in Sources */,
 				E0F413F01CF632120085166C /* SRKTransaction.m in Sources */,
@@ -885,6 +912,7 @@
 				E0F413BA1CF632120085166C /* SRKEncryptedObject.m in Sources */,
 				E0C450C61D10865A003FA21D /* Query.m in Sources */,
 				E0F413D01CF632120085166C /* SRKQueryProfile.m in Sources */,
+				E040B5C31D14970D00FCC830 /* Joins.m in Sources */,
 				E0F413AE1CF632120085166C /* SRKEventRegistryObject.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SharkORM/Core/Queries/SRKQuery.m
+++ b/SharkORM/Core/Queries/SRKQuery.m
@@ -45,7 +45,7 @@
 			
 			ptr++;
 			
-			NSRange currentParamHolder;
+			NSRange currentParamHolder = NSMakeRange(0, 0);
 			int pCount = 0;
 			const char* fmt = format.UTF8String;
 			
@@ -198,7 +198,7 @@
 			
 			ptr++;
 			
-			NSRange currentParamHolder;
+			NSRange currentParamHolder = NSMakeRange(0, 0);
 			int pCount = 0;
 			
 			const char* fmt = format.UTF8String;

--- a/SharkORM/Core/Queries/SRKQuery.m
+++ b/SharkORM/Core/Queries/SRKQuery.m
@@ -356,9 +356,32 @@
 
 - (SRKQuery*)joinTo:(Class)joinClass leftParameter:(NSString*)leftParameter targetParameter:(NSString*)targetParameter {
 	
-	SRKJoinObject* join = [[SRKJoinObject new] setJoinOn:joinClass joinWhere:[NSString stringWithFormat:@"%@.%@ = %@.%@", [self.classDecl description], leftParameter, [joinClass description], targetParameter] joinLeft:leftParameter joinRight:targetParameter];
+    // check to see if the 'left parameter' is actually a fully qualified field label such as "Department.location", if so this could be using the result of a previous join to join to a subsequent table.  But even if xxxxxx.fieldname is == to self.class it doesn't matter.  Do the same for the right.
+    
+    NSString* fromEntityClass = [self.classDecl description];
+    NSString* toEntityClass = [joinClass description];
+    
+    NSString* completeLeftParameter = @"";
+    
+    if (![leftParameter containsString:@"."]) {
+        completeLeftParameter = [NSString stringWithFormat:@"%@.%@", fromEntityClass, leftParameter];
+    } else {
+        completeLeftParameter = leftParameter;
+    }
+    
+    NSString* completeRightParameter = @"";
+    
+    if (![targetParameter containsString:@"."]) {
+        completeRightParameter = [NSString stringWithFormat:@"%@.%@", toEntityClass, targetParameter];
+    } else {
+        completeRightParameter = targetParameter;
+    }
+    
+    SRKJoinObject* join = [[SRKJoinObject new] setJoinOn:joinClass joinWhere:[NSString stringWithFormat:@"%@ = %@", completeLeftParameter, completeRightParameter] joinLeft:leftParameter joinRight:targetParameter];
+    
+    [self.joins addObject:join];
+    
 	
-	[self.joins addObject:join];
 	
 	return self;
 }

--- a/SharkORM/Core/SRKDefinitions.h
+++ b/SharkORM/Core/SRKDefinitions.h
@@ -49,6 +49,10 @@
 #define SRK_COMMIT_TRANSACTION_STATEMENT		@"COMMIT TRANSACTION;"
 #define SRK_ROLLBACK_TRANSACTION_STATEMENT		@"ROLLBACK TRANSACTION;"
 
+#define SRK_FIELD_NAME_FORMAT                   @"%@.%@ as result$%@"
+#define SRK_JOINED_FIELD_NAME_FORMAT            @", %@.%@ as result$%@_$_%@"
+
+
 #define SRK_DEFAULT_PRIMARY_KEY_NAME				@"Id"
 
 #define SuppressPerformSelectorLeakWarning(Stuff) \

--- a/SharkORM/Core/SharkORM.m
+++ b/SharkORM/Core/SharkORM.m
@@ -1822,7 +1822,7 @@ void stringFromDate(sqlite3_context *context, int argc, sqlite3_value **argv)
 				
 				if (query.lightweightObject && !query.prefetch) {
 					
-					getFieldList = [getFieldList stringByAppendingFormat:@"%@.%@ as result$%@", tableName, SRK_DEFAULT_PRIMARY_KEY_NAME, SRK_DEFAULT_PRIMARY_KEY_NAME];
+					getFieldList = [getFieldList stringByAppendingFormat:SRK_FIELD_NAME_FORMAT, tableName, SRK_DEFAULT_PRIMARY_KEY_NAME, SRK_DEFAULT_PRIMARY_KEY_NAME];
 					
 				} else if (query.lightweightObject && query.prefetch) {
 					
@@ -1832,7 +1832,7 @@ void stringFromDate(sqlite3_context *context, int argc, sqlite3_value **argv)
 							getFieldList = [getFieldList stringByAppendingString:@", "];
 						}
 						
-						getFieldList = [getFieldList stringByAppendingFormat:@"%@.%@ as result$%@", tableName, qFieldName, qFieldName];
+						getFieldList = [getFieldList stringByAppendingFormat:SRK_FIELD_NAME_FORMAT, tableName, qFieldName, qFieldName];
 					}
 					
 				}
@@ -1846,7 +1846,7 @@ void stringFromDate(sqlite3_context *context, int argc, sqlite3_value **argv)
 						}
 						
                         // TODO:  This line is 31.7% of the query time of the sequential insert and random read test.
-						getFieldList = [getFieldList stringByAppendingFormat:@"%@.%@ as result$%@", tableName, qFieldName, qFieldName];
+						getFieldList = [getFieldList stringByAppendingFormat:SRK_FIELD_NAME_FORMAT, tableName, qFieldName, qFieldName];
 					}
 					
 				}
@@ -1881,7 +1881,7 @@ void stringFromDate(sqlite3_context *context, int argc, sqlite3_value **argv)
 			/* now build up the additional selects for the joined data */
 			
 			for (NSString* qFieldName in [tableSchemas objectForKey:[join.joinOn description]]) {
-				getFieldList = [getFieldList stringByAppendingFormat:@", %@.%@ as result$%@_$_%@", [join.joinOn description], qFieldName, [join.joinOn description],qFieldName];
+				getFieldList = [getFieldList stringByAppendingFormat:SRK_JOINED_FIELD_NAME_FORMAT, [join.joinOn description], qFieldName, [join.joinOn description],qFieldName];
 			}
 		}
 		

--- a/SharkORMTests/Examples/Examples.h
+++ b/SharkORMTests/Examples/Examples.h
@@ -1,0 +1,13 @@
+//
+//  Examples.h
+//  SharkORM
+//
+//  Created by Adrian Herridge on 17/06/2016.
+//  Copyright © 2016 Adrian Herridge. All rights reserved.
+//
+
+#import "BaseTestCase.h"
+
+@interface Examples : BaseTestCase
+
+@end

--- a/SharkORMTests/Examples/Examples.m
+++ b/SharkORMTests/Examples/Examples.m
@@ -1,0 +1,41 @@
+//
+//  Examples.m
+//  SharkORM
+//
+//  Created by Adrian Herridge on 17/06/2016.
+//  Copyright © 2016 Adrian Herridge. All rights reserved.
+//
+
+#import "Examples.h"
+
+@implementation Examples
+
+- (void)test_basic_example_methods {
+    
+    /* clear all pre-existing data from the entity class */
+    [[[Person query] fetchLightweight] removeAll];
+    
+    /* now create a new object ready for persistence */
+    Person* newPerson = [Person new];
+    
+    // set some values
+    newPerson.Name = @"Adrian";
+    newPerson.age = 38;
+    newPerson.payrollNumber = 12345678;
+    
+    [newPerson commit];
+    
+    /* getting objects back again */
+    
+    SRKResultSet* results = [[Person query] fetch];
+    for (Person* p in results) {
+        
+        // modify the record and then commit the change back in again
+        p.age +=1;
+        [p commit];
+        
+    }
+    
+}
+
+@end

--- a/SharkORMTests/Joins/Joins.h
+++ b/SharkORMTests/Joins/Joins.h
@@ -1,0 +1,13 @@
+//
+//  Joins.h
+//  SharkORM
+//
+//  Created by Adrian Herridge on 17/06/2016.
+//  Copyright © 2016 Adrian Herridge. All rights reserved.
+//
+
+#import "BaseTestCase.h"
+
+@interface Joins : BaseTestCase
+
+@end

--- a/SharkORMTests/Joins/Joins.m
+++ b/SharkORMTests/Joins/Joins.m
@@ -1,0 +1,141 @@
+//
+//  Joins.m
+//  SharkORM
+//
+//  Created by Adrian Herridge on 17/06/2016.
+//  Copyright © 2016 Adrian Herridge. All rights reserved.
+//
+
+#import "Joins.h"
+
+@implementation Joins
+
+- (void)setupData {
+    
+    [self cleardown];
+    
+    Location* l = [Location new];
+    l.locationName = @"Alton";
+    
+    Department* d = [Department new];
+    d.name = @"Development";
+    d.location = l;
+    
+    Person* p = [Person new];
+    p.Name = @"Adrian";
+    p.age = 37;
+    p.department = d;
+    p.location = l;
+    [p commit];
+    
+}
+
+- (void)test_single_join {
+    
+    [self setupData];
+    
+    // pull out a single object but use join to join to the department class and not the relationship
+    Person * p = [[[[Person query] joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"] fetch] firstObject];
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([p.joinedResults objectForKey:@"Department.name"],@"join failed, no results returned for first join");
+}
+
+- (void)test_multiple_join {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[Person query]
+                    joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
+                    joinTo:[Location class] leftParameter:@"location" targetParameter:@"Id"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([[p.joinedResults objectForKey:@"Department.name"] isEqualToString:@"Development"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isEqualToString:@"Alton"],@"join failed, no results returned for second join");
+}
+
+- (void)test_multiple_join_with_fail_on_second_join {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[Person query]
+                     joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
+                    joinTo:[Location class] leftParameter:@"Name" targetParameter:@"Id"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([p.joinedResults objectForKey:@"Department.name"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isKindOfClass:[NSNull class]],@"join failed, no results returned for second join");
+}
+
+- (void)test_multiple_join_with_fail_on_second_join_test_for_null_in_where {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[[Person query]
+                      where:@"Location.Id IS NULL"]
+                     joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
+                    joinTo:[Location class] leftParameter:@"Name" targetParameter:@"Id"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([p.joinedResults objectForKey:@"Department.name"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isKindOfClass:[NSNull class]],@"join failed, no results returned for first join");
+}
+
+- (void)test_multiple_join_with_joined_table_referenced_in_where {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[[Person query]
+                     joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
+                    joinTo:[Location class] leftParameter:@"location" targetParameter:@"Id"]
+                    where:@"Location.locationName = 'Alton'"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([[p.joinedResults objectForKey:@"Department.name"] isEqualToString:@"Development"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isEqualToString:@"Alton"],@"join failed, no results returned for second join");
+}
+
+- (void)test_multiple_join_chaining_join_one_and_two {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[Person query]
+                     joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
+                    joinTo:[Location class] leftParameter:@"Department.location" targetParameter:@"Id"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([[p.joinedResults objectForKey:@"Department.name"] isEqualToString:@"Development"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isEqualToString:@"Alton"],@"join failed, no results returned for second join");
+}
+
+- (void)test_multiple_join_specifying_fully_qualified_field_names {
+    
+    [self setupData];
+    
+    // pull out a single object but use 2 joins to join to the department &  class and not the relationship
+    Person * p = [[[[[Person query]
+                     joinTo:[Department class] leftParameter:@"Person.department" targetParameter:@"Department.Id"]
+                    joinTo:[Location class] leftParameter:@"Department.location" targetParameter:@"Location.Id"]
+                   fetch]
+                  firstObject];
+    
+    XCTAssert(p, @"failed to retrieve and object when using a single join");
+    XCTAssert([[p.joinedResults objectForKey:@"Department.name"] isEqualToString:@"Development"],@"join failed, no results returned for first join");
+    XCTAssert([[p.joinedResults objectForKey:@"Location.locationName"] isEqualToString:@"Alton"],@"join failed, no results returned for second join");
+}
+
+@end

--- a/SharkORMTests/Performance Tests/Performance.m
+++ b/SharkORMTests/Performance Tests/Performance.m
@@ -37,7 +37,7 @@
             
         }
         
-        for (int i=0; i < 10000; i++) {
+        for (int i=0; i < 1000; i++) {
             SRKResultSet* r = [[[[Person query] whereWithFormat:@"seq = %i", rand() % 9999] limit:1] fetch];
         }
         

--- a/SharkORMTests/Sample Objects/Person.h
+++ b/SharkORMTests/Sample Objects/Person.h
@@ -7,6 +7,7 @@
 
 #import "SharkORM.h"
 #import "Department.h"
+#import "Location.h"
 
 @interface Person : SRKObject
 
@@ -15,5 +16,6 @@
 @property int               seq;
 @property int               payrollNumber;
 @property Department*       department;
+@property Location*         location;
 
 @end

--- a/SharkORMTests/Sample Objects/Person.m
+++ b/SharkORMTests/Sample Objects/Person.m
@@ -9,7 +9,7 @@
 
 @implementation Person
 
-@dynamic Name,age,department,payrollNumber,seq;
+@dynamic Name,age,department,payrollNumber,seq,location;
 
 + (NSArray *)FTSParametersForEntity {
 	return @[@"Name"];


### PR DESCRIPTION
```
JOIN: Added join tests & fixed bugs with join.  …
```

This turned up some faults when you wanted to Query C From A through a B join.  So, if you specifically specified the FQ field name it failed, because the ORM attemoted to prepent the self.class name.

Structure:
Person->Deaprtment->Location

Code example:
Person \* p = [[[[[Person query]
                     joinTo:[Department class] leftParameter:@"department" targetParameter:@"Id"]
                    joinTo:[Location class] leftParameter:@"Department.location" targetParameter:@"Id"]
                   fetch]
                  firstObject];
