### PR TITLE
Support for composite indicies of indeterminate length

### DIFF
--- a/SharkORM.xcodeproj/project.pbxproj
+++ b/SharkORM.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		3A330F631D25461500483626 /* SRKObjectChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A330F611D25461500483626 /* SRKObjectChain.m */; };
 		3A330F641D25461500483626 /* SRKObjectChain.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A330F611D25461500483626 /* SRKObjectChain.m */; };
 		3A44877E1D1E857B00BD9CB5 /* OtherTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A44877D1D1E857B00BD9CB5 /* OtherTests.m */; };
+		6915F03E1F2A51EF008B9842 /* SRKIndexProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 6915F03C1F2A51EF008B9842 /* SRKIndexProperty.m */; };
+		6915F0411F2A54DF008B9842 /* SRKCompoundIndex+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 6915F03F1F2A54DF008B9842 /* SRKCompoundIndex+Private.h */; };
+		6915F0421F2A54DF008B9842 /* SRKCompoundIndex.m in Sources */ = {isa = PBXBuildFile; fileRef = 6915F0401F2A54DF008B9842 /* SRKCompoundIndex.m */; };
 		E00320471CFA58FF00240C44 /* Department.m in Sources */ = {isa = PBXBuildFile; fileRef = E003203A1CFA58FF00240C44 /* Department.m */; };
 		E00320481CFA58FF00240C44 /* MostObjectTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = E003203C1CFA58FF00240C44 /* MostObjectTypes.m */; };
 		E00320491CFA58FF00240C44 /* Person.m in Sources */ = {isa = PBXBuildFile; fileRef = E003203E1CFA58FF00240C44 /* Person.m */; };
@@ -150,6 +153,9 @@
 		3A330F611D25461500483626 /* SRKObjectChain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRKObjectChain.m; sourceTree = "<group>"; };
 		3A44877C1D1E857B00BD9CB5 /* OtherTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OtherTests.h; sourceTree = "<group>"; };
 		3A44877D1D1E857B00BD9CB5 /* OtherTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OtherTests.m; sourceTree = "<group>"; };
+		6915F03C1F2A51EF008B9842 /* SRKIndexProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRKIndexProperty.m; sourceTree = "<group>"; };
+		6915F03F1F2A54DF008B9842 /* SRKCompoundIndex+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SRKCompoundIndex+Private.h"; sourceTree = "<group>"; };
+		6915F0401F2A54DF008B9842 /* SRKCompoundIndex.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SRKCompoundIndex.m; sourceTree = "<group>"; };
 		E00320391CFA58FF00240C44 /* Department.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Department.h; sourceTree = "<group>"; };
 		E003203A1CFA58FF00240C44 /* Department.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Department.m; sourceTree = "<group>"; };
 		E003203B1CFA58FF00240C44 /* MostObjectTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MostObjectTypes.h; sourceTree = "<group>"; };
@@ -538,6 +544,9 @@
 			children = (
 				E0F413711CF632120085166C /* SRKIndexDefinition+Private.h */,
 				E0F413721CF632120085166C /* SRKIndexDefinition.m */,
+				6915F03F1F2A54DF008B9842 /* SRKCompoundIndex+Private.h */,
+				6915F0401F2A54DF008B9842 /* SRKCompoundIndex.m */,
+				6915F03C1F2A51EF008B9842 /* SRKIndexProperty.m */,
 			);
 			path = Indexing;
 			sourceTree = "<group>";
@@ -643,6 +652,7 @@
 				E0F413BE1CF632120085166C /* SRKResultSet+Private.h in Headers */,
 				E0F413E61CF632120085166C /* SRKSQLiteHandle.h in Headers */,
 				E09B720D1D4F530A00B68A80 /* SRKAES256Extension.h in Headers */,
+				6915F0411F2A54DF008B9842 /* SRKCompoundIndex+Private.h in Headers */,
 				E0F413C61CF632120085166C /* SRKJoinObject.h in Headers */,
 				E0F413EC1CF632120085166C /* SRKContext.h in Headers */,
 				E0F413C91CF632120085166C /* SRKQuery+Private.h in Headers */,
@@ -764,12 +774,14 @@
 				E0F413CD1CF632120085166C /* SRKQueryAsyncHandler.m in Sources */,
 				E0F413C71CF632120085166C /* SRKJoinObject.m in Sources */,
 				E0F413C21CF632120085166C /* SRKUnsupportedObject.m in Sources */,
+				6915F03E1F2A51EF008B9842 /* SRKIndexProperty.m in Sources */,
 				E0F413CF1CF632120085166C /* SRKQueryProfile.m in Sources */,
 				E0F413A41CF632120085166C /* SRKEvent.m in Sources */,
 				E0F413B01CF632120085166C /* FTSRegistry.m in Sources */,
 				E0F413AD1CF632120085166C /* SRKEventRegistryObject.m in Sources */,
 				E0F413BC1CF632120085166C /* SRKObject.m in Sources */,
 				E0F413E71CF632120085166C /* SRKSQLiteHandle.m in Sources */,
+				6915F0421F2A54DF008B9842 /* SRKCompoundIndex.m in Sources */,
 				E0F413BF1CF632120085166C /* SRKResultSet.m in Sources */,
 				E0F413CA1CF632120085166C /* SRKQuery.m in Sources */,
 				E09B720E1D4F530A00B68A80 /* SRKAES256Extension.m in Sources */,

--- a/SharkORM/Core/Indexing/SRKCompoundIndex+Private.h
+++ b/SharkORM/Core/Indexing/SRKCompoundIndex+Private.h
@@ -1,0 +1,33 @@
+//    MIT License
+//
+//    Copyright (c) 2016 SharkSync
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+@interface SRKCompoundIndex : NSObject
+
+@property (strong) NSArray* indexProperties;
+
+- (id)initWithProperties:(NSArray*) indexProperties;
+- (NSString*) getIndexName;
+- (NSString*) getPropertyString;
+
+@end

--- a/SharkORM/Core/Indexing/SRKCompoundIndex.m
+++ b/SharkORM/Core/Indexing/SRKCompoundIndex.m
@@ -1,0 +1,79 @@
+//    MIT License
+//
+//    Copyright (c) 2016 SharkSync
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
+
+#import "SRKCompoundIndex+Private.h"
+#import "SharkORM.h"
+
+@implementation SRKCompoundIndex
+
+- (id)initWithProperties:(NSArray*) indexProperties {
+    self = [super init];
+    
+    if (self != nil) {
+        _indexProperties = indexProperties;
+    }
+    
+    return self;
+}
+
+-(NSString*) getIndexName {
+    NSString* indexName = @"idx_*tablename";
+    for (SRKIndexProperty *indexProperty in [self indexProperties]) {
+        indexName = [indexName stringByAppendingString:[NSString stringWithFormat:@"_%@_%@", indexProperty.name, [indexProperty getSortOrderIndexName]]];
+    }
+    return indexName;
+}
+
+-(NSString*) getPropertyString {
+    NSString* propertyString = @"(";
+    NSString* delim = @"";
+    
+    for (SRKIndexProperty *indexProperty in [self indexProperties]) {
+        propertyString = [propertyString stringByAppendingString:[NSString stringWithFormat:@"%@%@ %@", delim, indexProperty.name,[indexProperty getSortOrderString]]];
+        delim = @", ";
+    }
+    
+    propertyString = [propertyString stringByAppendingString:@")"];
+    
+    return propertyString;
+}
+
+
+- (BOOL) isEqual:(id)object {
+    if (object == self) {
+        return YES;
+    }
+    if (!object || ![object isKindOfClass:[self class]]) {
+        return NO;
+    }
+    return [[self getIndexName] isEqual:[object getIndexName]];
+}
+
+-(NSUInteger)hash {
+    NSUInteger result = 1;
+    NSUInteger prime = 31;
+    
+    result = prime * result + [[self getIndexName] hash];
+    
+    return result;
+}
+@end

--- a/SharkORM/Core/Indexing/SRKIndexDefinition.m
+++ b/SharkORM/Core/Indexing/SRKIndexDefinition.m
@@ -26,101 +26,64 @@
 #import "SharkORM.h"
 #import "SRKIndexDefinition+Private.h"
 #import "SharkORM+Private.h"
+#import "SRKCompoundIndex+Private.h"
 
 @implementation SRKIndexDefinition
 
+- (void)addIndexWithProperties: (SRKIndexProperty *)indexProperty, ... NS_REQUIRES_NIL_TERMINATION {
+    if (!_components) {
+        _components = [NSMutableArray new];
+    }
+    
+    NSMutableArray *properties = [[NSMutableArray alloc] init];
+    SRKIndexProperty *eachProperty;
+    va_list argumentList;
+    if (indexProperty) {
+        [properties addObject:indexProperty];
+        va_start(argumentList, indexProperty);
+        while ((eachProperty = va_arg(argumentList, SRKIndexProperty*)) != nil) {
+            [properties addObject:eachProperty];
+        }
+        va_end(argumentList);
+    }
+    
+    
+    SRKCompoundIndex *index = [[SRKCompoundIndex alloc] initWithProperties:properties];
+    
+    /* check for a duplicate */
+    BOOL found = NO;
+    for (SRKCompoundIndex* compoundIndex in _components) {
+        if ([compoundIndex isEqual:index]) {
+            found = YES;
+        }
+    }
+    if (!found) {
+        [_components addObject:index];
+    }
+}
+
 - (void)addIndexForProperty:(NSString *)propertyName propertyOrder:(enum SRKIndexSortOrder)propOrder {
-	
-	if (!_components) {
-		_components = [NSMutableArray new];
-	}
-	
-	NSMutableDictionary* d = [NSMutableDictionary new];
-	[d setObject:[NSString stringWithFormat:@"idx_*tablename_%@_%@", propertyName, (propOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc"] forKey:@"name"];
-	[d setObject:propertyName forKey:@"priProperty"];
-	
-	if (propOrder == SRKIndexSortOrderAscending) {
-		[d setObject:@"asc"forKey:@"priOrder"];
-	} else if (propOrder == SRKIndexSortOrderDescending) {
-		[d setObject:@"desc"forKey:@"priOrder"];
-	} else if (propOrder == SRKIndexSortOrderNoCase) {
-		[d setObject:@"collate nocase"forKey:@"priOrder"];
-	}
-	
-	/* check for a duplicate */
-	BOOL found = NO;
-	for (NSDictionary* dict in _components) {
-		NSString* name = [dict objectForKey:@"name"];
-		if ([name isEqualToString:[NSString stringWithFormat:@"idx_*tablename_%@_%@", propertyName, (propOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc"]]) {
-			found = YES;
-		}
-	}
-	if (!found) {
-		[_components addObject:d];
-	}
-	
+    
+    SRKIndexProperty * property = [[SRKIndexProperty alloc] initWithName:propertyName andOrder:propOrder];
+    
+    [self addIndexWithProperties:property, nil];
+    
 }
 
 - (void)addIndexForProperty:(NSString *)propertyName propertyOrder:(enum SRKIndexSortOrder)propOrder secondaryProperty:(NSString *)secProperty secondaryOrder:(enum SRKIndexSortOrder)secOrder {
-	
-	if (!_components) {
-		_components = [NSMutableArray new];
-	}
-	
-	NSMutableDictionary* d = [NSMutableDictionary new];
-	[d setObject:[NSString stringWithFormat:@"idx_*tablename_%@_%@_%@_%@", propertyName, (propOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc", secProperty, (secOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc"] forKey:@"name"];
-	[d setObject:propertyName forKey:@"priProperty"];
-	
-	if (propOrder == SRKIndexSortOrderAscending) {
-		[d setObject:@"asc"forKey:@"priOrder"];
-	} else if (propOrder == SRKIndexSortOrderDescending) {
-		[d setObject:@"desc"forKey:@"priOrder"];
-	} else if (propOrder == SRKIndexSortOrderNoCase) {
-		[d setObject:@"collate nocase"forKey:@"priOrder"];
-	}
-	
-	[d setObject:secProperty forKey:@"secProperty"];
-	if (secOrder == SRKIndexSortOrderAscending) {
-		[d setObject:@"asc" forKey:@"secOrder"];
-	} else if (secOrder == SRKIndexSortOrderDescending) {
-		[d setObject:@"desc" forKey:@"secOrder"];
-	} else if (secOrder == SRKIndexSortOrderNoCase) {
-		[d setObject:@"collate nocase"forKey:@"secOrder"];
-	}
-	
-	/* check for a duplicate */
-	BOOL found = NO;
-	for (NSDictionary* dict in _components) {
-		NSString* name = [dict objectForKey:@"name"];
-		if ([name isEqualToString:[NSString stringWithFormat:@"idx_*tablename_%@_%@_%@_%@", propertyName, (propOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc", secProperty, (secOrder == SRKIndexSortOrderAscending) ? @"asc" : @"desc"]]) {
-			found = YES;
-		}
-	}
-	if (!found) {
-		[_components addObject:d];
-	}
-	
+    SRKIndexProperty * property = [[SRKIndexProperty alloc] initWithName:propertyName andOrder:propOrder];
+    SRKIndexProperty * secondProperty = [[SRKIndexProperty alloc] initWithName:secProperty andOrder:secOrder];
+    
+    [self addIndexWithProperties:property, secondProperty, nil];
+
 }
 
 - (void)generateIndexesForTable:(NSString*)tableName inDatabase:(NSString *)dbName{
-	
-	for (NSDictionary* d in _components) {
-		
-		if ([d objectForKey:@"secProperty"] == nil) {
-			
-			NSString* execSql = [NSString stringWithFormat:@"CREATE INDEX %@ ON %@ (%@ %@);", [d objectForKey:@"name"], tableName, [d objectForKey:@"priProperty"], [d objectForKey:@"priOrder"]];
-			execSql = [execSql stringByReplacingOccurrencesOfString:@"*tablename" withString:tableName];
-			[SharkORM executeSQL:execSql inDatabase:dbName];
-			
-		} else {
-			
-			NSString* execSql = [NSString stringWithFormat:@"CREATE INDEX %@ ON %@ (%@ %@, %@ %@);", [d objectForKey:@"name"], tableName, [d objectForKey:@"priProperty"], [d objectForKey:@"priOrder"], [d objectForKey:@"secProperty"], [d objectForKey:@"secOrder"]];
-			execSql = [execSql stringByReplacingOccurrencesOfString:@"*tablename" withString:tableName];
-			[SharkORM executeSQL:execSql inDatabase:dbName];
-		}
-		
+	for (SRKCompoundIndex* index in _components) {
+        NSString* execSql = [NSString stringWithFormat:@"CREATE INDEX %@ ON %@ %@;", [index getIndexName], tableName, [index getPropertyString]];
+        execSql = [execSql stringByReplacingOccurrencesOfString:@"*tablename" withString:tableName];
+        [SharkORM executeSQL:execSql inDatabase:dbName];
 	}
-	
 }
 
 @end

--- a/SharkORM/Core/Indexing/SRKIndexProperty.m
+++ b/SharkORM/Core/Indexing/SRKIndexProperty.m
@@ -1,0 +1,64 @@
+//    MIT License
+//
+//    Copyright (c) 2016 SharkSync
+//
+//    Permission is hereby granted, free of charge, to any person obtaining a copy
+//    of this software and associated documentation files (the "Software"), to deal
+//    in the Software without restriction, including without limitation the rights
+//    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//    copies of the Software, and to permit persons to whom the Software is
+//    furnished to do so, subject to the following conditions:
+//
+//    The above copyright notice and this permission notice shall be included in all
+//    copies or substantial portions of the Software.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//    SOFTWARE.
+
+#import "SharkORM.h"
+
+@implementation SRKIndexProperty
+
+-(id) initWithName:(NSString *)columnName {
+    return [self initWithName:columnName andOrder:SRKIndexSortOrderAscending];
+}
+
+-(id) initWithName:(NSString*)columnName andOrder:(enum SRKIndexSortOrder) sortOrder {
+    self =  [super init];
+    
+    if (self != nil) {
+        _name = columnName;
+        _order = sortOrder;
+    }
+    return self;
+}
+
+-(NSString*) getSortOrderString {
+    if (_order == SRKIndexSortOrderAscending) {
+        return @"asc";
+    } else if (_order == SRKIndexSortOrderDescending) {
+        return @"desc";
+    } else if (_order == SRKIndexSortOrderNoCase) {
+        return @"collate nocase";
+    }
+    return nil;
+}
+
+-(NSString*) getSortOrderIndexName {
+    if (_order == SRKIndexSortOrderAscending) {
+        return @"asc";
+    } else if (_order == SRKIndexSortOrderDescending) {
+        return @"desc";
+    } else if (_order == SRKIndexSortOrderNoCase) {
+        /* This is named for backwards compatibility reasons, fixing the bug now will cause people to create an additional index within their database that does the same thing */
+        return @"desc";
+    }
+    return nil;
+}
+
+@end

--- a/SharkORM/Core/SharkORM.h
+++ b/SharkORM/Core/SharkORM.h
@@ -39,6 +39,7 @@
 @class SRKFTSQuery;
 @class SRKTransaction;
 @class SRKRawResults;
+@class SRKIndexProperty;
 
 typedef void(^SRKTransactionBlockBlock)();
 
@@ -286,6 +287,15 @@ enum SRKIndexSortOrder {
  * @return void
  */
 - (void)addIndexForProperty:(NSString*)propertyName propertyOrder:(enum SRKIndexSortOrder)propOrder;
+
+/**
+ * Adds the definition for a compound index with an indefinite number of properties
+ *
+ * @param indexProperty A list of properties that makes up the compound index
+ * @return void
+ */
+- (void)addIndexWithProperties: (SRKIndexProperty *)indexProperty, ...;
+
 /**
  * Adds a composite index on a given object with a sub index on an additional property.
  *
@@ -1005,6 +1015,49 @@ typedef void(^SRKQueryAsyncResponse)(SRKResultSet* results);
  * @return (NSString*), the column name to be used in queries.
  */
 - (NSString*)columnNameForIndex:(NSInteger)index;
+
+@end
+
+/**
+ * A SRKIndexProperty is used to store the name and sort order of a single column within a compound index
+ *
+ *
+ */
+@interface SRKIndexProperty : NSObject
+
+@property (strong) NSString*   name;
+@property enum SRKIndexSortOrder order;
+
+/**
+ * Formats the object's SRKIndexSortOrder into the string representation necessary for creating indices
+ *
+ * @return (NSString) the string representation of the sort order
+ */
+-(NSString*) getSortOrderString;
+
+/**
+ * Formats the object's SRKIndexSortOrder into the string representation necessary for naming indices
+ *
+ * @return (NSString) the string representation of the sort order
+ */
+-(NSString*) getSortOrderIndexName;
+
+/**
+ * Initializes a new SRKIndexProperty object
+ *
+ * @param (NSString*)columnName The named column used within the index
+ * @param (enum SRKIndexSortOrder)sortOrder The direction in which the index should sort
+ * @return (id)
+ */
+-(id) initWithName:(NSString*)columnName andOrder:(enum SRKIndexSortOrder) sortOrder;
+
+/**
+ * Initializes a new SRKIndexProperty object with a default sort order of Ascending
+ *
+ * @param (NSString*)columnName The named column used within the index
+ * @return (id)
+ */
+-(id) initWithName:(NSString*)columnName;
 
 @end
 


### PR DESCRIPTION
Added support for an indeterminate number of  fields to be added to a composite index through the new api method 

- (void)addIndexWithProperties: (SRKIndexProperty *)indexProperty, ...

Additionally rather than dealing with dictionaries and random strings, I introduced the concept of an Index Property which can be defined either via a name or by a name and sort order.

All existing API's have remained functional. So user's can continue to use the previous API commands to create indices, however they all flow through the central addIndexWithProperties function.

