### PR TITLE
fixing sharkorm creation of tables in swift 4, xcode 9.4

### DIFF
--- a/SharkORM/Core/SharkSchemaManager.m
+++ b/SharkORM/Core/SharkSchemaManager.m
@@ -566,7 +566,7 @@ static SharkSchemaManager* this;
 
 - (void)refactorDatabase:(NSString*)database entity:(NSString*)entity {
     
-    if (!database || [database isEqualToString:@""]) {
+    if (database != nil || [database isEqualToString:@""]) {
         
         // this is blank, so grab the default
         


### PR DESCRIPTION
@editfmah 

The tables were not being created in my local environment.

XCode 9.4.1
Swift 4.1

I couldn't confirm the fix doesn't break backwards compatibility but it does fix the table creation in for my project. I'd love to run unit tests if you give me a quick walkthrough. 