### PR TITLE
Fix a crashing bug in SRKEntity's asDictionary

### DIFF
--- a/SharkORM/Core/PersistableObjects/SRKEntity.m
+++ b/SharkORM/Core/PersistableObjects/SRKEntity.m
@@ -1593,7 +1593,11 @@ static void setPropertyCharPTRIMP(SRKEntity* self, SEL _cmd, char* aValue) {
     
     NSMutableDictionary* newDic = [NSMutableDictionary new];
     for (NSString* f in self.fieldNames) {
-        [newDic setObject:[self getField:f] forKey:f];
+        id value = [self getField:f];
+        
+        if (!value)
+            value = [NSNull null];
+        [newDic setObject:value forKey:f];
     }
     
     return [NSDictionary dictionaryWithDictionary:newDic];

--- a/SharkORMTests/Other Tests/OtherTests.m
+++ b/SharkORMTests/Other Tests/OtherTests.m
@@ -40,15 +40,22 @@
     Person* p = [Person new];
     
     p.age = 65;
+    p.payrollNumber = 100001;
     p.Name = nil;
     NSDictionary* dict = [p asDictionary];
     
     NSLog(@"dict: %@", dict);
     
+    XCTAssert([dict[@"Id"] isEqual:[NSNull null]], @"dict[Id] is wrong!");
+    XCTAssert([dict[@"age"] isEqual:@(65)], @"dict[age] is wrong!");
+    XCTAssert([dict[@"payrollNumber"] isEqual:@(100001)], @"dict[payrollNumber] is wrong!");
+    XCTAssert([dict[@"Name"] isEqual:[NSNull null]], @"dict[Name] is wrong!");
+
     Person* p2 = [[Person alloc] initWithDictionary:dict];
     
-    XCTAssert(p2.age == 65 ,@"failed to establish age");
-    XCTAssert(p2.Name == nil ,@"failed to clear name");
+    XCTAssert(p2.age == 65,@"failed to establish age");
+    XCTAssert(p2.payrollNumber == 100001,@"failed to establish payrollNumber");
+    XCTAssert(p2.Name == nil, @"failed to clear name");
 }
 
 @end

--- a/SharkORMTests/Other Tests/OtherTests.m
+++ b/SharkORMTests/Other Tests/OtherTests.m
@@ -36,4 +36,19 @@
     NSLog(@"%@",p);
 }
 
+- (void)test_asDictionary {
+    Person* p = [Person new];
+    
+    p.age = 65;
+    p.Name = nil;
+    NSDictionary* dict = [p asDictionary];
+    
+    NSLog(@"dict: %@", dict);
+    
+    Person* p2 = [[Person alloc] initWithDictionary:dict];
+    
+    XCTAssert(p2.age == 65 ,@"failed to establish age");
+    XCTAssert(p2.Name == nil ,@"failed to clear name");
+}
+
 @end


### PR DESCRIPTION
SRKEntity's asDictionary crashes when faced with properties containing nil values.  The problem is that asDictionary attempts to set the dictionary's key value to nil which generates a Cocoa exception.  My fix substitutes NSNull for nil which is compatible with how initWithDictionary operates.
