### PR TITLE
Bug fix for https://github.com/sharksync/sharkorm/issues/127

### DIFF
--- a/SharkORM/Core/PersistableObjects/SRKEntity.m
+++ b/SharkORM/Core/PersistableObjects/SRKEntity.m
@@ -2440,7 +2440,7 @@ static void setPropertyCharPTRIMP(SRKEntity* self, SEL _cmd, char* aValue) {
         if (queryString.length != 0) {
             
         }
-        if ([[[self.class query] where:queryString parameters:@[propertyValues]] count]) {
+        if ([[[self.class query] where:queryString parameters:propertyValues] count]) {
             return NO;
         }
     }


### PR DESCRIPTION
This PR fixes an issue with `uniquePropertiesForClass` not working as expected and throwing an exception due to an array variable not being handled correctly.